### PR TITLE
Better handling of complex trigger elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+	<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+	<title>EZPZ modification</title>
+	<script type="text/javascript" src="http://code.jquery.com/jquery-latest.js"></script>
+	<script type="text/javascript" src="jquery.ezpz_tooltip.js"></script>
+	<script type="text/javascript">
+		function ajax_load_content(content) {
+			$(content).empty();
+			window.setTimeout(function() {
+				ajax_simulate_reply(content)
+			}, 200);
+		}
+		function ajax_simulate_reply(content) {
+			$(content).text("AJAX content loaded!");
+		};
+		
+		$(document).ready(function() {
+			$("#example-target-1").ezpz_tooltip({beforeShow:ajax_load_content});
+			$("#example-target-2").ezpz_tooltip({beforeShow:ajax_load_content, stayOnContent:true,contentPosition: 'rightStatic', offset:-40});
+			$("#example-target-3").ezpz_tooltip({beforeShow:ajax_load_content, contentId:'non_convention_content'});
+		});
+	</script>
+	<style type="text/css">
+		p.tooltip-target { 
+			padding:20px;
+			border:2px solid red;
+			float:left;
+			margin:20px;
+		} 
+		div.tooltip-content {
+			display: none;        /* required */
+			position: absolute;   /* required */
+			padding: 10px;
+			border: 1px solid black;
+			background-color: lightgreen;
+		}
+	</style>
+</head>
+<body>
+	<h1>EZPZ test</h1>
+	<h3>Everything in the red border should show a tooltip</h3>
+	<div>
+		<p id="example-target-1" class="tooltip-target">
+			<a href="http://example.com">Non-static tooltip</a>
+		</p>
+		<p id="example-target-2" class="tooltip-target">
+			<a href="http://example.com">Static tooltip with stayOnContent</a>
+		</p>
+		<p id="example-target-3" class="tooltip-target">
+			<a href="http://example.com">Tooltip with explicit contentId</a>
+		</p>
+	</div>
+	<div class="tooltip-content" id="example-content-1">Tooltip content</div>
+	<div class="tooltip-content" id="example-content-2">Tooltip content</div>
+	<div class="tooltip-content" id="non_convention_content">Tooltip content</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,11 +16,21 @@
 		function ajax_simulate_reply(content) {
 			$(content).text("AJAX content loaded!");
 		};
+		function ajax_load_content_alternate(content) {
+			$(content).empty();
+			window.setTimeout(function() {
+				ajax_simulate_reply_alternate(content)
+			}, 200);
+		}
+		function ajax_simulate_reply_alternate(content) {
+			$(content).text("Alternate AJAX content loaded!");
+		};
 		
 		$(document).ready(function() {
 			$("#example-target-1").ezpz_tooltip({beforeShow:ajax_load_content});
 			$("#example-target-2").ezpz_tooltip({beforeShow:ajax_load_content, stayOnContent:true,contentPosition: 'rightStatic', offset:-40});
-			$("#example-target-3").ezpz_tooltip({beforeShow:ajax_load_content, contentId:'non_convention_content'});
+			$("#example-target-3").ezpz_tooltip({beforeShow:ajax_load_content, contentId:'non_convention_content', stayOnContent:true,contentPosition: 'rightStatic', offset:-40});
+			$("#example-target-5").ezpz_tooltip({beforeShow:ajax_load_content_alternate, contentId:'non_convention_content', stayOnContent:true,contentPosition: 'rightStatic', offset:-40});
 		});
 	</script>
 	<style type="text/css">
@@ -51,6 +61,9 @@
 		</p>
 		<p id="example-target-3" class="tooltip-target">
 			<a href="http://example.com">Tooltip with explicit contentId</a>
+		</p>
+		<p id="example-target-5" class="tooltip-target">
+			<a href="http://example.com">Sharing the same tooltip container via explicit contentId</a>
 		</p>
 	</div>
 	<div class="tooltip-content" id="example-content-1">Tooltip content</div>

--- a/jquery.ezpz_tooltip.js
+++ b/jquery.ezpz_tooltip.js
@@ -6,6 +6,11 @@
     return this.each(function(){
       var content = $("#" + getContentId(this.id));
 			var targetMousedOver = $(this);
+			var state = {
+				overTrigger: false,
+				overContent: false,
+				contentShown: false
+			};
 			
 			var fPositionContent = function(e) {
 				var contentInfo = getElementDimensionsAndPosition(content);
@@ -19,33 +24,33 @@
         settings.showContent(content);
 			}
 			var fHideContent = function() {
-					if (targetMousedOver.data("overTrigger") || targetMousedOver.data("overContent")) return;
-					targetMousedOver.data("showing", false);
+					if (state.overTrigger || state.overContent) return;
+					state.contentShown = false;
 					settings.hideContent(content);
           settings.afterHide();
 			}
 			
 			targetMousedOver
 				.mouseenter(function(e){
-					targetMousedOver.data("overTrigger", true)
-					if (targetMousedOver.data("showing")) return; //prevent re-showing a shown popup
+					state.overTrigger = true;
+					if (state.contentShown) return; //prevent re-showing a shown popup
 					settings.beforeShow(content, $(this));
-					targetMousedOver.data("showing", true);
+					state.contentShown = true;
 					fPositionContent(e);
 				})
 				.mousemove(fPositionContent)
 				.mouseleave(function() {
-					targetMousedOver.data("overTrigger", false)
+					state.overTrigger = false;
 					window.setTimeout(fHideContent, 0);
 				});
 			
 			if (settings.stayOnContent) {
 				content
 					.mouseenter(function() {
-						targetMousedOver.data("overContent", true)
+						state.overContent = true;
 					})
 					.mouseleave(function() {
-						targetMousedOver.data("overContent", false)
+						state.overContent = false;
 						window.setTimeout(fHideContent, 0);
 					});
 			};

--- a/jquery.ezpz_tooltip.js
+++ b/jquery.ezpz_tooltip.js
@@ -185,5 +185,19 @@
 
     return contentInfo;
   };
+	
+	$.fn.ezpz_tooltip.positions.belowRightStatic = function(contentInfo, mouseX, mouseY, offset, targetInfo) {
+		contentInfo['top'] = targetInfo['top'] + targetInfo['height'] + offset;
+		contentInfo['left'] = targetInfo['left'] + targetInfo['width'] + offset;
+		
+		return contentInfo;
+	};
+	
+	$.fn.ezpz_tooltip.positions.underTarget = function(contentInfo, mouseX, mouseY, offset, targetInfo) {
+		contentInfo['top'] = targetInfo['top'] + targetInfo['height'] + offset;
+		contentInfo['left'] = targetInfo['left'];
+		
+		return contentInfo;
+	};
 
 })(jQuery);

--- a/jquery.ezpz_tooltip.js
+++ b/jquery.ezpz_tooltip.js
@@ -5,11 +5,11 @@
 
     return this.each(function(){
       var content = $("#" + getContentId(this.id));
-      var targetMousedOver = $(this).mouseover(function(){
-        settings.beforeShow(content, $(this));
-      }).mousemove(function(e){
-        var contentInfo = getElementDimensionsAndPosition(content);
-        var targetInfo  = getElementDimensionsAndPosition($(this));
+			var targetMousedOver = $(this);
+			
+			var fPositionContent = function(e) {
+				var contentInfo = getElementDimensionsAndPosition(content);
+        var targetInfo  = getElementDimensionsAndPosition(targetMousedOver);
         var contentInfo = $.fn.ezpz_tooltip.positions[settings.contentPosition](contentInfo, e.pageX, e.pageY, settings.offset, targetInfo);
         var contentInfo = keepInWindow(contentInfo);
 
@@ -17,23 +17,38 @@
         content.css('left', contentInfo['left']);
 
         settings.showContent(content);
-      });
-
-      if (settings.stayOnContent && this.id != "") {
-        $("#" + this.id + ", #" + getContentId(this.id)).mouseover(function(){
-          content.css('display', 'block');
-        }).mouseout(function(){
-          content.css('display', 'none');
+			}
+			var fHideContent = function() {
+					if (targetMousedOver.data("overTrigger") || targetMousedOver.data("overContent")) return;
+					targetMousedOver.data("showing", false);
+					settings.hideContent(content);
           settings.afterHide();
-        });
-      }
-      else {
-        targetMousedOver.mouseout(function(){
-          settings.hideContent(content);
-          settings.afterHide();
-        })
-      }
-
+			}
+			
+			targetMousedOver
+				.mouseenter(function(e){
+					targetMousedOver.data("overTrigger", true)
+					if (targetMousedOver.data("showing")) return; //prevent re-showing a shown popup
+					settings.beforeShow(content, $(this));
+					targetMousedOver.data("showing", true);
+					fPositionContent(e);
+				})
+				.mousemove(fPositionContent)
+				.mouseleave(function() {
+					targetMousedOver.data("overTrigger", false)
+					fHideContent();//window.setTimeout(fHideContent, 150);
+				});
+			
+			if (settings.stayOnContent) {
+				content
+					.mouseenter(function() {
+						targetMousedOver.data("overContent", true)
+					})
+					.mouseleave(function() {
+						targetMousedOver.data("overContent", false)
+						fHideContent();//window.setTimeout(fHideContent, 150);
+					});
+			};
     });
 
     function getContentId(targetId){

--- a/jquery.ezpz_tooltip.js
+++ b/jquery.ezpz_tooltip.js
@@ -36,7 +36,7 @@
 				.mousemove(fPositionContent)
 				.mouseleave(function() {
 					targetMousedOver.data("overTrigger", false)
-					fHideContent();//window.setTimeout(fHideContent, 150);
+					window.setTimeout(fHideContent, 0);
 				});
 			
 			if (settings.stayOnContent) {
@@ -46,7 +46,7 @@
 					})
 					.mouseleave(function() {
 						targetMousedOver.data("overContent", false)
-						fHideContent();//window.setTimeout(fHideContent, 150);
+						window.setTimeout(fHideContent, 0);
 					});
 			};
     });


### PR DESCRIPTION
Hi,

We've been using ezpz-tooltips in one of our projects but we've had problems when the trigger element contains child elements; for the sake of discussion let's say we have a TD -> A situation and the tooltip trigger is set on the TD.

Whenever the mouse would pass from TD onto the A, the tooltip would disappear and appear again. This may not be noticable on smaller tooltips, but we've put quite a lot of data into ours and they are also AJAX loaded, so the flicker became problematic.

To conserve server resources, we made another adjustment for ourselves: we've added a delay option to the ezpz_tooltip constructor (I can push that to the main version if you are interested) so users wouldn't accidentaly trigger the AJAX tooltips and now the tooltip hide/show bug became REALLY annoying.

Anyways, just wanted to contribute back, pull this if you agree with the changes.
